### PR TITLE
Prepare for v1.0.0 release

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: "Build project"
         run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration Release
+
+      - name: "Test project"
+        run: dotnet test ${{ env.SOLUTION_PATH }} --no-restore --configuration Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,27 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+## [1.0.0] - 2023-05-28
+### Fixed
+- In case of Task cancellation for a Spigot build make sure the whole process tree is killed
+- Website (Mojang, Spigot) did not respond because AcceptEncoding has to be provided. Always add AcceptEncoding identity
+
+### Changed
+- Normalize names of Plugins e.g. SpigotMC is now just Spigot
+- Created temp folders during Spigot build include the Plugin name for easier identification 
+
+### Added
+- First working version
+- Unit testing project added
+- Add comment for old versions not proving Url due to missing server in Mojang Plugin Readme
+- Implement version filter in Spigot version factory
+- For Website crawling (Mojang, Spigot) add AcceptLanguage en-US, en to make sure content is not changed due to change of language
+- For Website crawling (Mojang, Spigot) add CacheControl with NoCache to get latest version of the website
+
+
+## [0.1.0] - 2023-05-28
+### Added
+- First working version
+
+
 This project is MIT Licensed // Created & maintained by Patrick Weiss

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Mohist/MohistProvider.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Mohist/MohistProvider.cs
@@ -16,7 +16,7 @@ public class MohistProvider : IProvider
     }
     
     public ProviderOptions ProviderOptions { get; }
-    public string Name => "MohistMC";
+    public string Name => "Mohist";
     public byte[] Logo => Properties.Resources.Mohist;
     public IEnumerable<IProject> Projects => MohistProjectFactory.Projects;
    

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Mojang/MojangVersionFactory.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Mojang/MojangVersionFactory.cs
@@ -76,6 +76,9 @@ internal static partial class MojangVersionFactory
 
         var request = new HttpRequestMessage(HttpMethod.Get, MojangBedrockRequestUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Text.Html));
+        request.Headers.AcceptEncoding.ParseAdd("identity");
+        request.Headers.AcceptLanguage.ParseAdd("en-US, en");
+        request.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
 
         var response = await HttpClient.SendAsync(request, cancellationToken);
 

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Mojang/README.md
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Mojang/README.md
@@ -25,3 +25,4 @@ If required the interface can be casted to it's instantiated classes.
   - For Bedrock an `Os` property is provided as the executables are compiled for Windows or Linux
 - `IDownload` to [MojangDownload](Model/MojangDownload.cs)
   - For Bedrock, no `Hash` or `ReleaseTime` is provided
+  - Older version did not provide as server therefore `Url` might be empty

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Paper/PaperProvider.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Paper/PaperProvider.cs
@@ -16,7 +16,7 @@ public class PaperProvider : IProvider
     }
     
     public ProviderOptions ProviderOptions { get; }
-    public string Name => "PaperMC";
+    public string Name => "Paper";
     public byte[] Logo => Properties.Resources.Paper;
     public IEnumerable<IProject> Projects => PaperProjectFactory.Projects;
 

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
@@ -85,7 +85,7 @@ public class SpigotBuildTools
         {
             await process.WaitForExitAsync(cancellationToken);
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException)
         {
             process.Kill(true);
             throw;

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Reflection;
 using MinecraftJars.Core.Downloads;
 using MinecraftJars.Plugin.Spigot.Model;
 
@@ -128,7 +129,7 @@ public class SpigotBuildTools
         string tempPath;
         do
         {
-            tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            tempPath = Path.Combine(Path.GetTempPath(), $"{Assembly.GetExecutingAssembly().GetName().Name}-{Guid.NewGuid().ToString()}");
         } while (Directory.Exists(tempPath));
 
         Directory.CreateDirectory(tempPath);

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotBuildTools.cs
@@ -79,8 +79,16 @@ public class SpigotBuildTools
             _ = Task.Run(() => ConnectOutput(process.StandardOutput), cancellationToken);
             _ = Task.Run(() => ConnectError(process.StandardError), cancellationToken);
         }
-        
-        await process.WaitForExitAsync(cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (TaskCanceledException ex)
+        {
+            process.Kill(true);
+            throw;
+        }
     }
     
     private async Task ConnectOutput(StreamReader output)

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotProvider.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotProvider.cs
@@ -16,7 +16,7 @@ public class SpigotProvider : IProvider
     }
 
     public ProviderOptions ProviderOptions { get; }
-    public string Name => "SpigotMC";
+    public string Name => "Spigot";
     public byte[] Logo => Properties.Resources.Spigot;
     public IEnumerable<IProject> Projects => SpigotProjectFactory.Projects;
     

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotVersionFactory.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotVersionFactory.cs
@@ -59,13 +59,14 @@ internal static partial class SpigotVersionFactory
 
         versions.AddRange(SpigotVersions()
             .Matches(html)
-            .Select(match => new SpigotVersion(
+            .Where(m => string.IsNullOrWhiteSpace(options.Version) || m.Groups["version"].Value.Equals(options.Version))
+            .Select(m => new SpigotVersion(
                 Project: project,
-                Version: match.Groups["version"].Value,
+                Version: m.Groups["version"].Value,
                 RequiresLocalBuild: true)
             {
-                DetailUrl = $"{SpigotRequestUri}/{match.Groups["json"].Value}",
-                ReleaseTime = DateTime.Parse(match.Groups["date"].Value, new CultureInfo("en-US"))
+                DetailUrl = $"{SpigotRequestUri}/{m.Groups["json"].Value}",
+                ReleaseTime = DateTime.Parse(m.Groups["date"].Value, new CultureInfo("en-US"))
             })            
             .OrderByDescending(v => v.ReleaseTime));
 
@@ -94,6 +95,7 @@ internal static partial class SpigotVersionFactory
         versions.AddRange(job.Builds
             .Where(b => !b.InProgress && 
                         b.Result.Equals("success", StringComparison.OrdinalIgnoreCase))
+            .Where(b => string.IsNullOrWhiteSpace(options.Version) || b.Number.ToString().Equals(options.Version))
             .Select(b => new SpigotVersion(
                 project, 
                 b.Number.ToString())

--- a/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotVersionFactory.cs
+++ b/MinecraftJars.Plugin/MinecraftJars.Plugin.Spigot/SpigotVersionFactory.cs
@@ -46,7 +46,10 @@ internal static partial class SpigotVersionFactory
         
         var request = new HttpRequestMessage(HttpMethod.Get, SpigotRequestUri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Text.Html));
-
+        request.Headers.AcceptEncoding.ParseAdd("identity");
+        request.Headers.AcceptLanguage.ParseAdd("en-US, en");
+        request.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
+        
         var response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (!response.IsSuccessStatusCode)

--- a/MinecraftJars.Tests/DownloadTests.cs
+++ b/MinecraftJars.Tests/DownloadTests.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using MinecraftJars.Core.Downloads;
+using MinecraftJars.Core.Versions;
+
+namespace MinecraftJars.Tests;
+
+[TestFixture, Order(4)]
+public class DownloadTests
+{
+    private static readonly ProviderManager ProviderManager = new ProviderManager();
+    private static IEnumerable<string> Projects() => 
+        ProviderManager.GetProviders().SelectMany(p => p.Projects.Select(t => t.Name));
+    
+    [Test, Order(1)]
+    [Ignore("Very time consuming should only be utilised when necessary")]
+    public async Task GetDownloads_Success(
+        [ValueSource(nameof(Projects))] string projectName,        
+        [Values(true, false)] bool loadFileSize)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+        
+        foreach (var version in await provider.GetVersions(project.Name))
+        {
+            TestContext.Progress.WriteLine("{0}: Retrieving download for version {1}", 
+                nameof(GetDownloads_Success), version.Version);
+            
+            var download = await version.GetDownload(new DownloadOptions { LoadFilesize = loadFileSize });
+            
+            Assert.That(download, Is.Not.Null);
+            Assert.That(download.BuildId, Has.Length.AtLeast(1));
+            if (loadFileSize && !string.IsNullOrWhiteSpace(download.Url))
+                Assert.That(download.Size, Is.AtLeast(1));
+            
+            TestContext.Progress.WriteLine("{0}: Download found with BuildId {1} and Url {2} for version {3} ", 
+                nameof(GetDownloads_Success), download.BuildId, download.Url, version.Version);
+        }
+    }
+    
+    [Test, Order(2)]
+    public async Task GetDownloads_LatestVersion(
+        [ValueSource(nameof(Projects))] string projectName,        
+        [Values(true, false)] bool loadFileSize)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+        var version = (await provider.GetVersions(project.Name, new VersionOptions { MaxRecords = 1 })).First();
+        
+        TestContext.Progress.WriteLine("{0}: Retrieving download for version {1}", 
+            nameof(GetDownloads_LatestVersion), version.Version);
+        
+        var download = await version.GetDownload(new DownloadOptions { LoadFilesize = loadFileSize });
+        
+        Assert.That(download, Is.Not.Null);
+        Assert.That(download.BuildId, Has.Length.AtLeast(1));
+        if (loadFileSize && !string.IsNullOrWhiteSpace(download.Url))
+            Assert.That(download.Size, Is.AtLeast(1));
+        
+        TestContext.Progress.WriteLine("{0}: Download found with BuildId {1} and Url {2} for version {3} ", 
+            nameof(GetDownloads_LatestVersion), download.BuildId, download.Url, version.Version);
+    }  
+    
+    [TestCase("Spigot"), Order(3)]
+    [Ignore("Very time consuming should only be utilised when necessary. Git and Java must be installed")]
+    public async Task BuildSpigot_Success(string projectName)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+        var version = (await provider.GetVersions(project.Name, new VersionOptions { MaxRecords = 1 })).First();
+        
+        TestContext.Progress.WriteLine("{0}: Start building {1} version {2}", 
+            nameof(BuildSpigot_Success), projectName, version.Version);
+        
+        var download = await version.GetDownload(new DownloadOptions
+        {
+            BuildJar = true, 
+            BuildJarOutput = TestContext.Progress.WriteLine
+        });
+
+        Assert.That(download, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(download.BuildId, Has.Length.AtLeast(1));
+            Assert.That(File.Exists(download.Url), Is.True);
+        });
+
+        TestContext.Progress.WriteLine("{0}: Build {1} finished with BuildId {2} and Url {3} for version {4} ", 
+            nameof(GetDownloads_LatestVersion), projectName, download.BuildId, download.Url, version.Version);
+
+        try
+        {
+            var path = Path.GetDirectoryName(download.Url);
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+        }
+        catch { /* ignore */ }
+    }
+    
+    [TestCase("Spigot"), Order(4)]
+    [Ignore("Very time consuming should only be utilised when necessary. Git and Java must be installed")]
+    public async Task BuildSpigot_Cancel(string projectName)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+        var version = (await provider.GetVersions(project.Name, new VersionOptions { MaxRecords = 1 })).First();
+        
+        TestContext.Progress.WriteLine("{0}: Start building {1} version {2}", 
+            nameof(BuildSpigot_Success), projectName, version.Version);
+
+        var startTime = Stopwatch.GetTimestamp();
+        var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        
+        Assert.ThrowsAsync<TaskCanceledException>(async () => 
+            await version.GetDownload(new DownloadOptions
+            {
+                BuildJar = true, 
+                BuildJarOutput = TestContext.Progress.WriteLine
+            }, cancellationTokenSource.Token));
+
+        var elapsedTime = Stopwatch.GetElapsedTime(startTime);
+        
+        Assert.That(elapsedTime.Seconds, Is.AtMost(15));
+        
+        TestContext.Progress.WriteLine("{0}: Build {1} successful cancelled after {2}s", 
+            nameof(GetDownloads_LatestVersion), projectName, elapsedTime.Seconds);
+    }    
+}

--- a/MinecraftJars.Tests/MinecraftJars.Tests.csproj
+++ b/MinecraftJars.Tests/MinecraftJars.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\MinecraftJars.Core\MinecraftJars.Core.csproj" />
+      <ProjectReference Include="..\MinecraftJars.Plugin\MinecraftJars.Plugin.Mohist\MinecraftJars.Plugin.Mohist.csproj" />
+      <ProjectReference Include="..\MinecraftJars.Plugin\MinecraftJars.Plugin.Mojang\MinecraftJars.Plugin.Mojang.csproj" />
+      <ProjectReference Include="..\MinecraftJars.Plugin\MinecraftJars.Plugin.Paper\MinecraftJars.Plugin.Paper.csproj" />
+      <ProjectReference Include="..\MinecraftJars.Plugin\MinecraftJars.Plugin.Purpur\MinecraftJars.Plugin.Purpur.csproj" />
+      <ProjectReference Include="..\MinecraftJars.Plugin\MinecraftJars.Plugin.Spigot\MinecraftJars.Plugin.Spigot.csproj" />
+      <ProjectReference Include="..\MinecraftJars\MinecraftJars.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/MinecraftJars.Tests/ProjectTests.cs
+++ b/MinecraftJars.Tests/ProjectTests.cs
@@ -1,0 +1,45 @@
+using MinecraftJars.Core.Projects;
+using MinecraftJars.Core.Providers;
+
+namespace MinecraftJars.Tests;
+
+[TestFixture, Order(2)]
+public class ProjectTests
+{
+    private static readonly ProviderManager ProviderManager = new();
+    private static IEnumerable<string> Providers() => ProviderManager.GetProviders().Select(p => p.Name);
+    private static IEnumerable<Group> Groups() => Enum.GetValues<Group>();
+    
+    [TestCaseSource(nameof(Providers)), Order(1)]
+    public void GetProviderByProject_Success(string providerName)
+    {
+        var provider = ProviderManager.GetProvider(providerName);
+        
+        foreach (var project in provider.Projects)
+        {
+            var providerByProject = ProviderManager.GetProvider(project);
+            Assert.That(providerByProject, Is.SameAs(provider));
+            
+            TestContext.Progress.WriteLine("{0}: Provider for project {1} is {2}", 
+                nameof(GetProviderByProject_Success), providerByProject.Name, project.Name);
+        }
+    }
+    
+    [TestCase, Order(2)]
+    public void GetProjects_Success()
+    {
+        var projects = ProviderManager.GetProjects().ToList();
+        Assert.That(projects, Is.Not.Empty);
+        
+        TestContext.Progress.WriteLine("{0}: {1} projects found", nameof(GetProjects_Success), projects.Count);
+    }
+    
+    [TestCaseSource(nameof(Groups)), Order(3)]
+    public void GetProjectsByGroup_Success(Group group)
+    {
+        var projects = ProviderManager.GetProjects(group).ToList();
+        Assert.That(projects.All(p => p.Group == group), Is.True);
+        
+        TestContext.Progress.WriteLine("{0}: {1} projects found for {2}", nameof(GetProjectsByGroup_Success), projects.Count, group);
+    }    
+}

--- a/MinecraftJars.Tests/ProviderTests.cs
+++ b/MinecraftJars.Tests/ProviderTests.cs
@@ -1,0 +1,54 @@
+using MinecraftJars.Core.Projects;
+
+namespace MinecraftJars.Tests;
+
+[TestFixture, Order(1)]
+public class ProviderTests
+{
+    private static readonly ProviderManager ProviderManager = new();
+    private static IEnumerable<Group> Groups() => Enum.GetValues<Group>();
+
+    [TestCase, Order(1)]
+    public void GetProviders_Success()
+    {
+        var providers = ProviderManager.GetProviders().ToList();
+        Assert.That(providers, Is.Not.Empty);
+        
+        TestContext.Progress.WriteLine("{0}: {1} providers found", nameof(GetProviders_Success), providers.Count);
+    }
+
+    [TestCaseSource(nameof(Groups)), Order(2)]
+    public void GetProvidersByGroup_Success(Group group) 
+    {
+         var providers = ProviderManager.GetProviders(group).ToList();
+         Assert.That(providers, Is.Not.Empty);
+         
+         TestContext.Progress.WriteLine("{0}: {1} providers found for {2}", nameof(GetProvidersByGroup_Success), providers.Count, group);
+    } 
+    
+    [TestCase(100), Order(3)]
+    public void GetProvidersByGroup_InvalidGroup(Group group)
+    {
+        Assert.That(ProviderManager.GetProviders(group), Is.Empty);
+        TestContext.Progress.WriteLine("{0}: Group {1} is invalid", nameof(GetProvidersByGroup_InvalidGroup), group);
+    }     
+    
+    [TestCase, Order(4)]
+    public void GetProviderByName_Success()
+    {
+        foreach (var name in ProviderManager.GetProviders().Select(p => p.Name))
+        {
+            var provider = ProviderManager.GetProvider(name);
+            Assert.That(provider, Is.Not.Null);
+            
+            TestContext.Progress.WriteLine("{0}: Provider for name {1} found", nameof(GetProviderByName_Success), name);
+        }
+    }
+
+    [TestCase("InvalidProviderName"), Order(5)]
+    public void GetProviderByName_InvalidProvider(string name)
+    {
+        Assert.Throws<InvalidOperationException>(() => ProviderManager.GetProvider(name));
+        TestContext.Progress.WriteLine("{0}: Provider name {1} invalid", nameof(GetProviderByName_InvalidProvider), name);
+    }
+}

--- a/MinecraftJars.Tests/Usings.cs
+++ b/MinecraftJars.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/MinecraftJars.Tests/VersionTests.cs
+++ b/MinecraftJars.Tests/VersionTests.cs
@@ -1,0 +1,62 @@
+using MinecraftJars.Core.Versions;
+using MinecraftJars.Plugin.Mojang.Models;
+
+namespace MinecraftJars.Tests;
+
+[TestFixture, Order(3)]
+public class VersionTests
+{
+    private static readonly ProviderManager ProviderManager = new ProviderManager();
+    private static IEnumerable<string> Projects() => 
+        ProviderManager.GetProviders().SelectMany(p => p.Projects.Select(t => t.Name));
+    
+    [TestCaseSource(nameof(Projects)), Order(1)]
+    public async Task GetVersions_Success(string projectName)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+        var versions = (await provider.GetVersions(project.Name)).ToList();
+
+        Assert.That(versions, Is.Not.Empty);
+        Assert.That(versions.All(v => v.Project.Name.Equals(project.Name)), Is.True);
+        
+        TestContext.Progress.WriteLine("{0}: {1} versions found for {2}", 
+            nameof(GetVersions_Success), versions.Count, project.Name);
+    }
+    
+    [Test, Order(2)]
+    public async Task GetVersions_MaxRecordsMax(
+        [ValueSource(nameof(Projects))] string projectName, 
+        [Values(5, 10)] int maxRecords)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+
+        var versions =
+            (await provider.GetVersions(project.Name, new VersionOptions { MaxRecords = maxRecords })).ToList();
+        Assert.That(versions, Has.Count.AtMost(maxRecords));
+        
+        TestContext.Progress.WriteLine("{0}: {1} versions found for {2} with max. limit {3}", 
+            nameof(GetVersions_MaxRecordsMax), versions.Count, project.Name, maxRecords);
+    }    
+
+    [TestCaseSource(nameof(Projects)), Order(3)]
+    public async Task GetVersions_SpecificVersion(string projectName)
+    {
+        var project = ProviderManager.GetProjects().Single(p => p.Name.Equals(projectName));
+        var provider = ProviderManager.GetProvider(project);
+
+        var version = (await provider.GetVersions(project.Name)).First();
+
+        var versions =
+            (await provider.GetVersions(project.Name, new VersionOptions { Version = version.Version })).ToList();
+
+        var count = version is MojangVersion { Os: not null } ? 2 : 1; 
+
+        Assert.That(versions, Has.Count.EqualTo(count));
+        Assert.That(versions.First(), Is.EqualTo(version));
+        
+        TestContext.Progress.WriteLine("{0}: Specific version {1} found", 
+            nameof(GetVersions_SpecificVersion), version.Version);
+    }  
+}

--- a/MinecraftJars.sln
+++ b/MinecraftJars.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinecraftJars.Plugin.Mohist
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinecraftJars.Plugin.Spigot", "MinecraftJars.Plugin\MinecraftJars.Plugin.Spigot\MinecraftJars.Plugin.Spigot.csproj", "{7C807B9A-3F6C-4373-91B6-F84251F5AF71}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinecraftJars.Tests", "MinecraftJars.Tests\MinecraftJars.Tests.csproj", "{62EA85E3-0307-466D-810D-8A5D2773A49A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,5 +56,9 @@ Global
 		{7C807B9A-3F6C-4373-91B6-F84251F5AF71}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C807B9A-3F6C-4373-91B6-F84251F5AF71}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C807B9A-3F6C-4373-91B6-F84251F5AF71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62EA85E3-0307-466D-810D-8A5D2773A49A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62EA85E3-0307-466D-810D-8A5D2773A49A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62EA85E3-0307-466D-810D-8A5D2773A49A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62EA85E3-0307-466D-810D-8A5D2773A49A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## [1.0.0] - 2023-05-28
### Fixed
- In case of Task cancellation for a Spigot build make sure the whole process tree is killed
- Website (Mojang, Spigot) did not respond because AcceptEncoding has to be provided. Always add AcceptEncoding identity

### Changed
- Normalize names of Plugins e.g. SpigotMC is now just Spigot
- Created temp folders during Spigot build include the Plugin name for easier identification 

### Added
- First working version
- Unit testing project added
- Add comment for old versions not proving Url due to missing server in Mojang Plugin Readme
- Implement version filter in Spigot version factory
- For Website crawling (Mojang, Spigot) add AcceptLanguage en-US, en to make sure content is not changed due to change of language
- For Website crawling (Mojang, Spigot) add CacheControl with NoCache to get latest version of the website